### PR TITLE
$usecloud is global for getImage()

### DIFF
--- a/PlantUML.php
+++ b/PlantUML.php
@@ -279,6 +279,7 @@ function getPageTitle($parser) {
  */
 function getImage($PlantUML_Source, $parser=null) {
     global $plantumlImagetype;
+    global $usecloud;
 
     // Compute hash
     $title_hash = md5(getPageTitle($parser));


### PR DESCRIPTION
It complained in apache2's error log like this:

```
PHP Notice:  Undefined variable: usecloud in .../PlantUML/PlantUML.php on line 298
```
