### PR TITLE
section editing and image path

### DIFF
--- a/PlantUML.body.php
+++ b/PlantUML.body.php
@@ -110,6 +110,7 @@ class	PlantUML {
 	 *	 if	set	the	use	the	given	format - it	may	be png or	svg
 	 */
 	function renderUML(	$input,	$args, Parser	$parser, PPFrame $frame	)	{
+		$parser->disableCache();
 		if (isset($args["format"]))	{
 			$format=$args["format"];
 			$format=$parser->recursiveTagParse(	$format, $frame	);

--- a/PlantUML.body.php
+++ b/PlantUML.body.php
@@ -1,75 +1,89 @@
 <?php
 /**
- * Copyright (C) 2010 Arnoud Roques
- * Copyright (C) 2011 Pieter J. Kersten
- * Copyright (C) 2016-2017 Wolfgang Fahl
+ * Copyright (C) 2010	Arnoud Roques
+ * Copyright (C) 2011	Pieter J.	Kersten
+ * Copyright (C) 2016-2017 Wolfgang	Fahl
+ * Copyright (C) 2019   Matthias	Oestreicher
  *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * This	program	is free	software;	you	can	redistribute it	and/or
+ * modify	it under the terms of	the	GNU	General	Public License
+ * as	published	by the Free	Software Foundation; either	version	2
+ * of	the	License, or	(at	your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This	program	is distributed in	the	hope that	it will	be useful,
+ * but WITHOUT ANY WARRANTY; without even	the	implied	warranty of
+ * MERCHANTABILITY or	FITNESS	FOR	A	PARTICULAR PURPOSE.	 See the
+ * GNU General Public	License	for	more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * You should	have received	a	copy of	the	GNU	General	Public License
+ * along with	this program;	if not,	write	to the Free	Software
+ * Foundation, Inc., 51	Franklin Street, Fifth Floor,	Boston,	MA	02110-1301,	USA.
  */
-use MediaWiki\Logger\LoggerFactory;
+use	MediaWiki\Logger\LoggerFactory;
 
 /**
- * the Plant UML extension main class
+ * the Plant UML extension main	class
  */
-class PlantUML {
+class	PlantUML {
 
 	/**
-	 * Register this extension with the WikiText parser.
-	 * The first parameter is the name of the new tag. In this case the
-	 * tag <uml> ... </uml>. The second parameter is the callback function
-	 * for processing the text between the tags.
+	 * Register	this extension with	the	WikiText parser.
+	 * The first parameter is	the	name of	the	new	tag. In	this case	the
+	 * tag <uml> ... </uml>. The second	parameter	is the callback	function
+	 * for processing	the	text between the tags.
 	 */
-	public static function onParserFirstCallInit( &$parser ) {
-		$puml = new self();
-		$parser->setHook( 'uml', [ $puml, 'renderUML' ] );
+	public static	function onParserFirstCallInit(	&$parser ) {
+		$puml	=	new	self();
+		$parser->setHook(	'uml', [ $puml,	'renderUML'	]	);
+		return true;
+	}
+
+
+	/**
+	 * Cover images	on PageContentSave
+	 */
+	public static	function onPageContentSave(	&$wikiPage,	&$user,	&$content, &$summary,
+		$isMinor,	$isWatch,	$section,	&$flags, &$status	)	{
+
+		$title = $wikiPage->getTitle()->getFulltext();
+
+		$puml	=	new	self();
+		$puml->coverImages($title);
+		return true;
+	}
+	/**
+	 * Clean images	on PageContentSaveComplete
+	 */
+	public static	function onPageViewUpdates(	$wikiPage, $user)	{
+
+		$title = $wikiPage->getTitle()->getFulltext();
+		$puml	=	new	self();
+		$puml->cleanImages($title);
 		return true;
 	}
 
 	/**
-	 * Clean the image folder when required
-	 */
-	public static function onPageContentSave( &$wikiPage, &$user, &$content, &$summary,
-		$isMinor, $isWatch, $section, &$flags, &$status ) {
-
-		$puml = new self();
-		$puml->cleanImages();
-		return true;
-	}
-
-	/** 
 	 * construct me
 	 */
 	function __construct() {
 		// prepare error handling
 		$this->error=null;
 		// prepare logging
-		$this->logger = LoggerFactory::getInstance( 'PlantUML' );
+		$this->logger	=	LoggerFactory::getInstance(	'PlantUML' );
 		// check debugging options
 		$this->debug = $this->getProperty( 'Debug' );
-		if ($this->debug) {
+		if ($this->debug)	{
 			$this->logger->debug("PlantUML constructed");
 		}
 	}
 
 	/**
-	 * return an error Message
-   * @param $context - the context in which the error happened
-   * @return - the error message
-   */
+	 * return	an error Message
+	 * @param	$context - the context in	which	the	error	happened
+	 * @return - the error message
+	 */
 	function getErrorMsg($context) {
-		$errMsg="An error occured in the PlantUML extension."; // TODO i18n
+		$errMsg="An	error	occured	in the PlantUML	extension."; //	TODO i18n
 		if (isset($this->error)) {
 			$errMsg.="<br>".$this->error;
 		}
@@ -77,123 +91,133 @@ class PlantUML {
 	}
 
 	/**
-   * support debugging by either storing
-   * or in debug mode logging a debug message
-	 * @param msg - the message to store or log 
+	 * support debugging by	either storing
+	 * or	in debug mode	logging	a	debug	message
+	 * @param	msg	-	the	message	to store or	log
 	 */
 	function debug($msg) {
-		$this->msg=$msg; // TODO keep local log of issues
-		if ($this->debug) {
+		$this->msg=$msg; //	TODO keep	local	log	of issues
+		if ($this->debug)	{
 			$this->logger->debug($msg);
 		}
-  }
+	}
 
 	/**
-	 * This call back function renders UML with PlantUML based 
-	 * on the information provided by $input.
-	 *	
-	 * @param format
-	 *   if set the use the given format - it may be png or svg
+	 * This	call back	function renders UML with	PlantUML based
+	 * on	the	information	provided by	$input.
+	 *
+	 * @param	format
+	 *	 if	set	the	use	the	given	format - it	may	be png or	svg
 	 */
-	function renderUML( $input, $args, Parser $parser, PPFrame $frame ) {
-		if (isset($args["format"])) {
+	function renderUML(	$input,	$args, Parser	$parser, PPFrame $frame	)	{
+		if (isset($args["format"]))	{
 			$format=$args["format"];
-			$format=$parser->recursiveTagParse( $format, $frame );
-		} else {
-			$format=$this->getProperty( 'Format' );
+			$format=$parser->recursiveTagParse(	$format, $frame	);
+		}	else {
+			$format=$this->getProperty(	'Format' );
 		}
-		$image = $this->getImage($input, $args, $parser);
 
-		// if there is no image
-		if ($image['src'] == false) {
-			$text = $this->getErrorMsg($image);
-		} else {
-			if ($format == 'svg') {
-				$text = $this->renderSVG($image);
-			} else if ($format == 'png') {
-				$text = $this->renderPNG($image);
-			} else {
-				$text ="<span style='color:red'>PlantUML extension error - unknown format: ".$format."</span>";
+		$image = $this->getImage($input, $args,	$parser);
+
+		// if	there	is no	image
+		if ($image['src']	== false)	{
+			$text	=	$this->getErrorMsg($image);
+		}	else {
+			if ($format	== 'svg')	{
+				$text	=	$this->renderSVG($image);
+			}	else if	($format ==	'png') {
+				$text	=	$this->renderPNG($image);
+			}	else {
+				$text	="<span	style='color:red'>PlantUML extension error - unknown format: ".$format."</span>";
 			}
 		}
 		return $text;
 	}
 
 	/**
-	 * Tries to match the PlantUML given as argument against the cache.
-	 * If the picture has not been rendered before, it'll
-	 * try to render the PlantUML and drop it in the picture cache directory.
-	 * Embedded links will be expanded into a image map file with the same
-	 * name, but extension ".cmapx". When found, it will be included in the
+	 * Tries to	match	the	PlantUML given as	argument against the cache.
+	 * If	the	picture	has	not	been rendered	before,	it'll
+	 * try to	render the PlantUML	and	drop it	in the picture cache directory.
+	 * Embedded	links	will be	expanded into	a	image	map	file with	the	same
+	 * name, but extension ".cmapx". When	found, it	will be	included in	the
 	 * results.
 	 *
-	 * @param string model in been format
-	 * @returns an array with four elements:
-	 *   'src':   the webserver based URL to a picture which contains the
-	 *			requested PlantUML model. If anything fails, this value is
+	 * @param	string model in	been format
+	 * @returns	an array with	four elements:
+	 *	 'src':		the	webserver	based	URL	to a picture which contains	the
+	 *			requested	PlantUML model.	If anything	fails, this	value	is
 	 *			false.
-	 *   'file':  the full pathname to the file containing the image map data
-	 *			when present. When no map data is present, this value is empty.
-	 *   'map':   the rendered HTML-fragment for an image map. Empty when not
+	 *	 'file':	the	full pathname	to the file	containing the image map data
+	 *			when present.	When no	map	data is	present, this	value	is empty.
+	 *	 'map':		the	rendered HTML-fragment for an	image	map. Empty when	not
 	 *			needed.
-	 * 'mapid': the unique id for the rendered image map , useable for further
+	 * 'mapid':	the	unique id	for	the	rendered image map , useable for further
 	 *			HTML-rendering.
 	 */
-	function getImage($PlantUML_Source, $argv, $parser=null) {
+	function getImage($PlantUML_Source,	$argv, $parser=null) {
 		// Compute hash
-		$title=$this->getPageTitle($parser);
-		$title_hash = md5($title);
-		$formula_hash = md5($PlantUML_Source);
+		$title=$parser->getTitle()->getFulltext();;
+		$title_hash	=	md5($title);
+		$formula_hash	=	md5($PlantUML_Source);
 
 		$filename_prefix = 'uml-'.$title_hash."-".$formula_hash;
-		$dirname = $this->getUploadDirectory();
-		$full_path_prefix = $dirname."/".$filename_prefix;
+		$dirname = $this->getUploadDirectory().'/plantuml';
+		if (!is_dir($dirname)) mkdir($dirname);
 		$imgFile = $dirname."/".$filename_prefix.".".$this->getProperty('Format');
-		$mapFile = $dirname."/".$filename_prefix.".map";
-		// setup the result map
-		$result = array(
-			'title' => $title, 'mapid' => $formula_hash, 'src' => false, 'map' => '', 'file' => ''
+		$mapFile = $dirname."/".$filename_prefix.".cmapx";
+		// setup the result	map
+		$result	=	array(
+			'title'	=> $title, 'mapid' =>	$formula_hash, 'src' =>	false, 'map' =>	'',	'file' =>	''
 		);
-		// Check cache. When found, reuse it. When not, generate image.
-		// Honor the redraw tag as found in <uml redraw>
-		if (is_file($imgFile) and is_file($mapFile) and !array_key_exists('redraw', $argv) ) {
-			$result['file'] = $imgFile;
+		// handle	covered	Images
+		$imgsearchFile = $dirname."/latest-".$filename_prefix.".".$this->getProperty('Format');
+		$mapsearchFile = $dirname."/latest-".$filename_prefix.".cmapx";
+		if (is_file($imgsearchFile)) {
+				rename($imgsearchFile, $imgFile);
+		}
+		if (is_file($mapsearchFile)) {
+				rename($mapsearchFile, $mapFile);
+		}
+
+		// Check cache.	When found,	reuse	it.	When not,	generate image.
+		// Honor the redraw	tag	as found in	<uml redraw>
+		if (is_file($imgFile) and !array_key_exists('redraw',	$argv) ) {
+			$result['file']	=	$imgFile;
 			$result['mapfile'] = $mapFile;
-		} else {
-			if ($this->getProperty( 'UseCloud' )) {
-				$result['file'] = $this->renderPlantUML_cloud($PlantUML_Source, $imgFile);
+		}	else {
+			if ($this->getProperty(	'UseCloud' ))	{
+				$result['file']	=	$this->renderPlantUML_cloud($PlantUML_Source,	$imgFile);
 				$result['mapfile'] = $this->renderPlantUML_cloud_map($PlantUML_Source, $mapFile);
-			} else {
-				$result['file'] = $this->renderPlantUML($PlantUML_Source, $imgFile, $dirname, $filename_prefix);
+			}	else {
+				$result['file']	=	$this->renderPlantUML($PlantUML_Source,	$imgFile,	$dirname,	$filename_prefix);
 			}
 		}
-		// do we have a mapfile?
-		if (isset($result['mapfile'])) {
-			if (is_file($result['mapfile'])) {
-				// map file is temporary data - read it and delete it.
-				$fp = fopen($result['mapfile'],'r');
-				$fsize=filesize($result['mapfile']);
-				if ($fsize>0)
-				  $image_map_data = fread($fp, $fsize);
-				fclose($fp);
-				if ($fsize>0) {
-				  // Replace generic ids with unique ids: first two ".." fields.
-				  $result['map'] = preg_replace('/"[^"]*"/', "\"{$result['mapid']}\"", $image_map_data, 2);
-				}
-			}
-		}
+//		// do	we have	a	mapfile?
+//		if (isset($result['mapfile'])) {
+//			if (is_file($result['mapfile'])) {
+//				// map file	is temporary data	-	read it	and	delete it.
+//				$fp	=	fopen($result['mapfile'],'r');
+//				$fsize=filesize($result['mapfile']);
+//				if ($fsize>0)
+//					$image_map_data	=	fread($fp, $fsize);
+//				fclose($fp);
+//				if ($fsize>0)	{
+//					// Replace generic ids with	unique ids:	first	two	".." fields.
+//					$result['map'] = preg_replace('/"[^"]*"/', "\"{$result['mapid']}\"", $image_map_data,	2);
+//				}
+//			}
+//		}
 		if ($result['file']) {
-			$result['src'] = $this->getUploadPath()."/".basename($result['file']);
-			if ((!$this->getProperty( 'UseCloud' )) && $this->getProperty('Format') == 'png') {
-				$map_filename = $full_path_prefix.".cmapx";
-				if (is_file($map_filename)) {
-					// map file is temporary data - read it and delete it.
-					$fp = fopen($map_filename,'r');
-					$image_map_data = fread($fp, filesize($map_filename));
+			$result['src'] = $this->getUploadPath()."/plantuml/".basename($result['file']);
+			if ((!$this->getProperty(	'UseCloud' ))	&& $this->getProperty('Format')	== 'png')	{
+				if (is_file($mapFile)) {
+					// map file	is temporary data	-	read it	and	delete it.
+					$fp	=	fopen($mapFile,'r');
+					$image_map_data	=	fread($fp, filesize($mapFile));
 					fclose($fp);
 					//unlink($map_filename);
-					// Replace generic ids with unique ids: first two ".." fields.
-					$result['map'] = preg_replace('/"[^"]*"/', "\"{$result['mapid']}\"", $image_map_data, 2);
+					// Replace generic ids with	unique ids:	first	two	".." fields.
+					$result['map'] = preg_replace('/"[^"]*"/', "\"{$result['mapid']}\"", $image_map_data,	2);
 				}
 			}
 		}
@@ -201,12 +225,12 @@ class PlantUML {
 	}
 
 	/**
-	 * You can change the result of the getUploadDirectory() and getUploadPath()
-	 * if you want to put generated images somewhere else.
-	 * By default, it equals the upload directory. Mind that the process creating
-	 * the images must be able to create new files there.
+	 * You can change	the	result of	the	getUploadDirectory() and getUploadPath()
+	 * if	you	want to	put	generated	images somewhere else.
+	 * By	default, it	equals the upload	directory. Mind	that the process creating
+	 * the images	must be	able to	create new files there.
 	 */
-	function getUploadDirectory() {
+	function getUploadDirectory()	{
 		global $wgUploadDirectory;
 		return $wgUploadDirectory;
 	}
@@ -220,62 +244,93 @@ class PlantUML {
 	}
 
 	/**
-	* Clean the image folder when required
+	*	Clean	 "latest"	images
+	*	previous Mediawiki hook	ArticleSaveComplete	changed	to PageContentSaveComplete.
+	*	But	the	new	hook it	is fired before	rendering	the	Article, so	getImage is	not	called between PageContentSave
+	*	and	PageContentSaveComplete. So	the	Images would have	been cleaned before	up-to-date-check in	getImage.
+	*	Workaround:	Create a "Timestamp" file	per	Article	on PageContentSave an	do cleanup on	PageViewUpdates	after	a	save delay...
 	*/
-	function cleanImages($parser=null) {
-		$title_hash = md5($this->getPageTitle($parser));
-		$path = $this->getUploadDirectory()."/uml-".$title_hash."-*.{svg,png,cmapx}";
-		$files = glob($path, GLOB_BRACE);
-		foreach ($files as $filename) {
-			unlink($filename);
+	function cleanImages($title) {
+		$title_hash	=	md5($title);
+		$lastEditFile	=	$this->getUploadDirectory().'/plantuml'."/uml-".$title_hash.".edittime";
+		if (is_file($lastEditFile)){
+			$timestamp = file_get_contents($lastEditFile);
+			if ($timestamp < date("YmdHis",	time()-120))
+			{
+				$path	=	$this->getUploadDirectory().'/plantuml'."/latest-uml-".$title_hash."-*.{svg,png,cmapx}";
+				$files = glob($path, GLOB_BRACE);
+				foreach	($files	as $filename)	{
+					unlink($filename);
+				}
+				unlink ($lastEditFile);
+			}
 		}
 		return true;
 	}
 
 	/**
-	* wraps a minimalistic PlantUML document around the formula and returns a string
-	* containing the whole document as string.
-	*
-	* @param string model in PlantUML format
-	* @returns minimalistic PlantUML document containing the given model
-	*/
-	function wrap_formula($PlantUML_Source) {
-		$string  = "@startuml\n";
-		// Allow ditaa and graphviz first-line directives and accents (french, ..)
-		// $string .= preg_replace("/^\r?\n/", "", utf8_decode($PlantUML_Source), 1) . "\n";
-		$string.=$PlantUML_Source;
-		$string .= "@enduml";
+	*	MOe: Cover images	as "latest", but down	delete them!
+	**/
+	function coverImages($title) {
+			$title_hash	=	md5($title);
+			$lastEditFile	=	$this->getUploadDirectory().'/plantuml'."/uml-".$title_hash.".edittime";
+			$path	=	$this->getUploadDirectory().'/plantuml'."/uml-".$title_hash."-*.{svg,png,cmapx}";
+			$files = glob($path, GLOB_BRACE);
+			if (count($files)	>	0) {
+				file_put_contents($lastEditFile, date("YmdHis"));
+			}
+			foreach	($files	as $filename)	{
+					rename($filename,	str_replace	("/uml-","/latest-uml-",$filename));
+			}
+			return true;
+}
 
+	/**
+	*	wraps	a	minimalistic PlantUML	document around	the	formula	and	returns	a	string
+	*	containing the whole document	as string.
+	*
+	*	@param string	model	in PlantUML	format
+	*	@returns minimalistic	PlantUML document	containing the given model
+	*/
+	function wrap_formula($PlantUML_Source)	{
+		$fromArray = $this->getProperty( 'FormulaReplaceFrom'	);
+		$toArray = $this->getProperty( 'FormulaReplaceTo'	);
+
+		$string	 = "@startuml\n";
+		// Allow ditaa and graphviz	first-line directives	and	accents	(french, ..)
+		// $string .=	preg_replace("/^\r?\n/", "", utf8_decode($PlantUML_Source),	1) . "\n";
+		$string	.= str_replace($fromArray,$toArray,$PlantUML_Source);
+		$string	.= "@enduml";
 		return $string;
 	}
 
 	/**
-	* Renders a PlantUML model by the using the following method:
-	*  - write the formula into a wrapped plantuml file
-	*  - Use a filename a md5 hash of the uml source
-	*  - Launch PlantUML to create the PNG file into the picture cache directory
+	*	Renders	a	PlantUML model by	the	using	the	following	method:
+	*	 - write the formula into	a	wrapped	plantuml file
+	*	 - Use a filename	a	md5	hash of	the	uml	source
+	*	 - Launch	PlantUML to	create the PNG file	into the picture cache directory
 	*
-	* @param string PlantUML_Source
-	* @param string imgFile: full path of to-be-generated image file.
-	* @param string dirname: directory of generated files
-	* @param string filename_prefix: unique prefix for $dirname
+	*	@param string	PlantUML_Source
+	*	@param string	imgFile: full	path of	to-be-generated	image	file.
+	*	@param string	dirname: directory of	generated	files
+	*	@param string	filename_prefix: unique	prefix for $dirname
 	*
-	* @returns the full path location of the rendered picture when
-	*		  successfull, false otherwise
+	*	@returns the full	path location	of the rendered	picture	when
+	*			successfull, false otherwise
 	*/
-	function renderPlantUML($PlantUML_Source, $imgFile, $dirname, $filename_prefix) {
+	function renderPlantUML($PlantUML_Source,	$imgFile,	$dirname,	$filename_prefix)	{
 		$PlantUML_document = $this->wrap_formula($PlantUML_Source);
 
-		// create temporary uml text file
+		// create	temporary	uml	text file
 		$umlFile = $dirname."/".$filename_prefix.".uml";
-		$fp = fopen($umlFile,"wb");
-		$w  = fputs($fp,mb_convert_encoding($PlantUML_document,'UTF-8'));
+		$fp	=	fopen($umlFile,"wb");
+		$w	=	fputs($fp,mb_convert_encoding($PlantUML_document,'UTF-8'));
 		fclose($fp);
 
 		// Lauch PlantUML
-		if ($this->getProperty( 'Format' ) == 'svg') {
+		if ($this->getProperty(	'Format' ) ==	'svg') {
 			$typestr = ' -tsvg';
-		} else {
+		}	else {
 			$typestr = '';
 		}
 
@@ -283,94 +338,96 @@ class PlantUML {
 		if (!is_file($jarFile) )
 			$jarFile = dirname(__FILE__).'/'.$jarFile;
 		if (!is_file($jarFile) ) {
-			$this->debug("$jarfile is missing");
+			$this->debug("$jarfile is	missing");
 			$this->error=$this->msg;
- 		}
+		}
+		$includePath = $this->getProperty( 'IncludePath' );
+		$includePath = dirname(__FILE__).'/'.$includePath;
+		$javaEnv = '';
+		if (is_dir($includePath) ) {
+			$javaEnv = '-Dplantuml.include.path='.$includePath;
+		}
 
-		$command = "java -jar ".$jarFile." ".
-				"{$typestr} -charset UTF-8 -o \"{$dirname}\" \"{$umlFile}\"";
+		$command = "java ".$javaEnv."	-jar ".$jarFile."	".
+				"{$typestr}	-charset UTF-8 -o	\"{$dirname}\" \"{$umlFile}\"";
 
-		// execute the java command
+		// execute the java	command
 		exec($command,$ouput,$status_code);
-		$this->debug("command '".$command."' returned status code=".$status_code."");
+		$this->debug("command	'".$command."' returned	status code=".$status_code."");
 		$this->error=$this->msg;
 
-		$this->debug("image file '".$imgFile."'");
+		$this->debug("image	file '".$imgFile."'");
 
-		// Only return existing path names.
+		// Only	return existing	path names.
 		if (is_file($imgFile)) {
-			// Delete temporary uml text file 
+			// Delete	temporary	uml	text file
 			unlink($umlFile);
 			return $imgFile;
-		} else {
-			$this->debug("image file is missing");
+		}	else {
+			$this->debug("image	file is	missing");
 			if (!$this->debug) {
-				// Delete temporary uml text file
+				// Delete	temporary	uml	text file
 				unlink($umlFile);
 			}
 		}
-
 		return false;
 	}
 
 	/**
-	* Renders a PlantUML model by the using the following method:
-	*  - Encode the source like explained here: http://plantuml.sourceforge.net/codephp.html
-	*  - Use as filename a md5 hash of the uml source
-	*  - Copy the image generated by http://www.plantuml.com in the upload directory
+	*	Renders	a	PlantUML model by	the	using	the	following	method:
+	*	 - Encode	the	source like	explained	here:	http://plantuml.sourceforge.net/codephp.html
+	*	 - Use as	filename a md5 hash	of the uml source
+	*	 - Copy	the	image	generated	by http://www.plantuml.com in	the	upload directory
 	*
-	* @param string PlantUML_Source: the source of the UML image
-	* @param string imgFile: full path of to-be-generated image file.
-	* @returns true if the picture has been successfully saved to the picture
-	*		  cache directory
+	*	@param string	PlantUML_Source: the source	of the UML image
+	*	@param string	imgFile: full	path of	to-be-generated	image	file.
+	*	@returns true	if the picture has been	successfully saved to	the	picture
+	*			cache	directory
 	*/
-	function renderPlantUML_cloud($PlantUML_Source, $imgFile) {
-		// Build URL that describes the image
-		$img = $this->getProperty( 'CloudURI' ) . $this->getProperty( 'Format' ) .'/';
-		$img .= $this->encodep($PlantUML_Source);
+	function renderPlantUML_cloud($PlantUML_Source,	$imgFile)	{
+		// Build URL that	describes	the	image
+		$img = $this->getProperty( 'CloudURI'	)	.	$this->getProperty(	'Format' ) .'/';
+		$img .=	$this->encodep($PlantUML_Source);
 
-		// Copy images into the local cache
+		// Copy	images into	the	local	cache
 		// -------------------------------------------
-		// patch by Boly31 to support proxies
+		// patch by	Boly31 to	support	proxies
 		// see https://www.mediawiki.org/wiki/Extension_talk:PlantUML#PlantUML_with_a_dedicated_plantuml_server_behind_proxy
 		$proxy = getenv("http_proxy");
-		// default no proxy behavior
-		if ($proxy == "") {
+		// default no	proxy	behavior
+		if ($proxy ==	"")	{
 			copy($img, $imgFile);
-		} else {
-		   $proxyOpt = "tcp://" . $proxy;
-
-		   $opts = array(
+		}	else {
+			 $proxyOpt = "tcp://"	.	$proxy;
+			 $opts = array(
 				'http'=>array
 				(
 					'method'=>"GET",
-					'proxy' => $proxyOpt,
-					'request_fulluri' => true
+					'proxy'	=> $proxyOpt,
+					'request_fulluri'	=> true
 				)
 			);
-		   $context = stream_context_create($opts);
-
-		   $contentx = file_get_contents($img,false,$context);
-		   $openedfile = fopen($imgFile, "w");
-		   fwrite($openedfile, $contentx);
-		   fclose($openedfile);
+			 $context	=	stream_context_create($opts);
+			 $contentx = file_get_contents($img,false,$context);
+			 $openedfile = fopen($imgFile, "w");
+			 fwrite($openedfile, $contentx);
+			 fclose($openedfile);
 		}
 		// -------------------------------------------
 
 		if (is_file($imgFile)) {
 			return $imgFile;
 		}
-
 		return false;
 	}
 
 
-	function renderPlantUML_cloud_map($PlantUML_Source, $mapFile) {
-		// Build URL that describes the image
-		$map = $this->getProperty( 'CloudURI' ) . 'map/';
-		$map .= $this->encodep($PlantUML_Source);
+	function renderPlantUML_cloud_map($PlantUML_Source,	$mapFile)	{
+		// Build URL that	describes	the	image
+		$map = $this->getProperty( 'CloudURI'	)	.	'map/';
+		$map .=	$this->encodep($PlantUML_Source);
 
-		// Copy images into the local cache
+		// Copy	images into	the	local	cache
 		copy($map, $mapFile);
 
 		if (is_file($mapFile)) {
@@ -380,133 +437,116 @@ class PlantUML {
 		return false;
 	}
 
-
 	/**
-	 * Get a title for this page.
-	 * @returns title
-	 */
-	function getPageTitle($parser) {
-		global $wgArticle;
-		global $wgTitle;
-	$title=$wgTitle;
-		// Retrieving the title of a page is not that easy
-		if (empty($wgTitle)) {
-		if ($parser!=null)	
-				$title = $parser->getTitle()->getFulltext();
-		}
-		return $title;
-	}
-
-	/**
-	 * renderSVG wraps a SVG-image in a correctly sized <object>
+	 * renderSVG wraps a SVG-image in	a	correctly	sized	<object>
 	 *
-	 * @param $image: the array of image data generated by getImage()
-	 * @returns: the rendered HTML string for the svg image.
+	 * @param	$image:	the	array	of image data	generated	by getImage()
+	 * @returns: the rendered	HTML string	for	the	svg	image.
 	 */
 	function renderSVG($image) {
-		// In essence, we don't have to embed the svg image ourselves, but it is
-		// imperative that we know the size of the object, otherwise it will clip.
-		$fp = fopen($image['file'],'r');
-		$data = fread($fp, 200);
+		// In	essence, we	don't	have to	embed	the	svg	image	ourselves, but it	is
+		// imperative	that we	know the size	of the object, otherwise it	will clip.
+		$fp	=	fopen($image['file'],'r');
+		$data	=	fread($fp, 200);
 		fclose($fp);
 		$parts = explode('><', $data);
-		$dimensions = preg_replace('/.*style="width:(\d+);height:(\d+);".*/', 'width=${1} height=${2}', $parts[1]);
+		$dimensions	=	preg_replace('/.*style="width:(\d+);height:(\d+);".*/',	'width=${1}	height=${2}',	$parts[1]);
 
 		#	'width="'.$width.'"'.' height="'.$height.'">'.
-		return '<object class="plantuml" type="image/svg+xml" data="'.$image['src'].'" '.
-			   $dimensions.
-			   '>Your browser has no SVG support. '.
-			   'Please install <a href="http://www.adobe.com/svg/viewer/install/">Adobe '.
-			   'SVG Viewer</a> plugin (for Internet Explorer) or use <a href="'.
-			   'http://www.getfirefox.com/">Firefox</a>, <a href="http://www.opera.com/">'.
-			   'Opera</a> or <a href="http://www.apple.com/safari/download/">Safari</a> '.
-			   'instead.'.
+		return '<object	class="plantuml" type="image/svg+xml"	data="'.$image['src'].'" '.
+				 $dimensions.
+				 '>Your	browser	has	no SVG support.	'.
+				 'Please install <a	href="http://www.adobe.com/svg/viewer/install/">Adobe	'.
+				 'SVG	Viewer</a> plugin	(for Internet	Explorer)	or use <a	href="'.
+				 'http://www.getfirefox.com/">Firefox</a>, <a	href="http://www.opera.com/">'.
+				 'Opera</a>	or <a	href="http://www.apple.com/safari/download/">Safari</a>	'.
+				 'instead.'.
 			 '</object>';
 	}
 
 	/**
-	 * renderPNG returns the correct HTML for the image in $image
+	 * renderPNG returns the correct HTML	for	the	image	in $image
 	 *
-	 * @param $image: the array of image data generated by getImage()
-	 * @returns: the rendered HTML string for the svg image.
+	 * @param	$image:	the	array	of image data	generated	by getImage()
+	 * @returns: the rendered	HTML string	for	the	svg	image.
 	 */
 	function renderPNG($image) {
 		if ($image['map']) {
-			$usemap = ' usemap="#'.$image['mapid'].'"';
-		} else {
-			$usemap = '';
+			$usemap	=	'	usemap="#'.$image['mapid'].'"';
+		}	else {
+			$usemap	=	'';
 		}
-		return "<img class=\"plantuml\" src=\"{$image['src']}\"$usemap>{$image['map']}";
+		return "<img class=\"plantuml\"	src=\"{$image['src']}\"$usemap>{$image['map']}";
 	}
 
 
 	/**
-	 * Return a property for plantuml using global, request or passed default
+	 * Return	a	property for plantuml	using	global,	request	or passed	default
 	 */
-	function getProperty( $name ) {
+	function getProperty(	$name	)	{
 		global $wgRequest;
 		$prefix="PlantUml";
-		if ( $wgRequest->getText( $prefix.$name ) )		return $wgRequest->getText( $prefix.$name );
-		if ( $wgRequest->getText( "amp;".$prefix.$name ) ) return $wgRequest->getText( "amp;".$prefix.$name ); // hack to handle ampersand entities in URL
-		$config = ConfigFactory::getDefaultInstance()->makeConfig( 'PlantUml' );
+		if ( $wgRequest->getText(	$prefix.$name	)	)		return $wgRequest->getText(	$prefix.$name	);
+		if ( $wgRequest->getText(	"amp;".$prefix.$name ) ) return	$wgRequest->getText( "amp;".$prefix.$name	); //	hack to	handle ampersand entities	in URL
+		$config	=	ConfigFactory::getDefaultInstance()->makeConfig( 'PlantUml'	);
 		return $config->get( $prefix.$name );
 	}
 
 	/**
-	 * PHP API Client Code
+	 * PHP API Client	Code
 	 * See http://plantuml.sourceforge.net/codephp.html
 	 */
-	function encodep($text) {
-		$data = mb_convert_encoding($text, 'UTF-8', mb_detect_encoding($text));
-		$compressed = gzdeflate($data, 9);
+	function encodep($text)	{
+		$data	=	mb_convert_encoding($text, 'UTF-8',	mb_detect_encoding($text));
+		$compressed	=	gzdeflate($data, 9);
 		return $this->encode64($compressed);
 	}
 
-	function encode6bit($b) {
+	function encode6bit($b)	{
 		if ($b < 10) {
-			return chr(48 + $b);
+			return chr(48	+	$b);
 		}
-		$b -= 10;
+		$b -=	10;
 		if ($b < 26) {
-			return chr(65 + $b);
+			return chr(65	+	$b);
 		}
-		$b -= 26;
+		$b -=	26;
 		if ($b < 26) {
-			return chr(97 + $b);
+			return chr(97	+	$b);
 		}
-		$b -= 26;
-		if ($b == 0) {
+		$b -=	26;
+		if ($b ==	0) {
 			return '-';
 		}
-		if ($b == 1) {
+		if ($b ==	1) {
 			return '_';
 		}
 		return '?';
 	}
 
-	function append3bytes($b1, $b2, $b3) {
-		$c1 = $b1 >> 2;
-		$c2 = (($b1 & 0x3) << 4) | ($b2 >> 4);
-		$c3 = (($b2 & 0xF) << 2) | ($b3 >> 6);
-		$c4 = $b3 & 0x3F;
+	function append3bytes($b1, $b2,	$b3) {
+		$c1	=	$b1	>> 2;
+		$c2	=	(($b1	&	0x3) <<	4) | ($b2	>> 4);
+		$c3	=	(($b2	&	0xF) <<	2) | ($b3	>> 6);
+		$c4	=	$b3	&	0x3F;
 		$r = "";
-		$r .= $this->encode6bit($c1 & 0x3F);
-		$r .= $this->encode6bit($c2 & 0x3F);
-		$r .= $this->encode6bit($c3 & 0x3F);
-		$r .= $this->encode6bit($c4 & 0x3F);
+		$r .=	$this->encode6bit($c1	&	0x3F);
+		$r .=	$this->encode6bit($c2	&	0x3F);
+		$r .=	$this->encode6bit($c3	&	0x3F);
+		$r .=	$this->encode6bit($c4	&	0x3F);
 		return $r;
 	}
 
-	function encode64($c) {
+	function encode64($c)	{
 		$str = "";
 		$len = strlen($c);
-		for ($i = 0; $i < $len; $i+=3) {
-			if ($i+2==$len) {
-				$str .= $this->append3bytes(ord(substr($c, $i, 1)), ord(substr($c, $i+1, 1)), 0);
-			} else if ($i+1==$len) {
-				$str .= $this->append3bytes(ord(substr($c, $i, 1)), 0, 0);
-			} else {
-				$str .= $this->append3bytes(ord(substr($c, $i, 1)), ord(substr($c, $i+1, 1)), ord(substr($c, $i+2, 1)));
+		for	($i	=	0; $i	<	$len;	$i+=3) {
+			if ($i+2==$len)	{
+				$str .=	$this->append3bytes(ord(substr($c, $i, 1)),	ord(substr($c, $i+1, 1)),	0);
+			}	else if	($i+1==$len) {
+				$str .=	$this->append3bytes(ord(substr($c, $i, 1)),	0, 0);
+			}	else {
+				$str .=	$this->append3bytes(ord(substr($c, $i, 1)),	ord(substr($c, $i+1, 1)),	ord(substr($c, $i+2, 1)));
 			}
 		}
 		return $str;

--- a/PlantUML.body.php
+++ b/PlantUML.body.php
@@ -110,7 +110,7 @@ class	PlantUML {
 	 *	 if	set	the	use	the	given	format - it	may	be png or	svg
 	 */
 	function renderUML(	$input,	$args, Parser	$parser, PPFrame $frame	)	{
-		$parser->disableCache();
+		$parser->getOutput()->updateCacheExpiry(0);
 		if (isset($args["format"]))	{
 			$format=$args["format"];
 			$format=$parser->recursiveTagParse(	$format, $frame	);

--- a/extension.json
+++ b/extension.json
@@ -5,7 +5,8 @@
         "Arnoud Roques",
         "Pieter J. Kersten",
         "Wolfgang Fahl",
-        "Frédéric Planchon"
+        "Frédéric Planchon",
+        "Matthias Oestreicher"
     ],
     "url": "https://www.mediawiki.org/wiki/Extension:PlantUML",
     "descriptionmsg": "plantuml-desc",
@@ -19,7 +20,12 @@
         "PlantUmlDebug": false,
         "PlantUmlCloudURI": "http://www.plantuml.com/plantuml/",
         "PlantUmlJarFile": "plantuml.jar",
-        "PlantUmlFormat": "svg"
+        "PlantUmlIncludePath": "include",
+        "PlantUmlFormat": "png",
+        "PlantUmlFormulaReplaceFrom": ["@startuml","@enduml"],
+        "PlantUmlFormulaReplaceTo": [],
+        "PlantUmlFormulaReplaceFromExample": ["[[MYWIKI","]]","@startuml","@enduml"],
+        "PlantUmlFormulaReplaceToExample": ["<font color=#00008B>[[http://mywiki/pathto/index.php","]]</font>"]
     },
     "ConfigRegistry": {
         "PlantUml": "GlobalVarConfig::newInstance"
@@ -35,6 +41,9 @@
         ],
         "PageContentSave": [
             "PlantUML::onPageContentSave"
+        ],
+        "PageViewUpdates": [
+            "PlantUML::onPageViewUpdates"
         ]
     },
     "MessagesDirs": {


### PR DESCRIPTION
After extending the PlantUML extension in 2014 for our local wiki, i had to do it again after upgrading mediawiki to the latest version. So now i decided to share my work ;-)

The biggest problem was, when editing large pages with several <uml> tags every image is regenerated even when there is no change in it. My enhancement is to cover/hide the images onPageContentSave and reactivate them in getImage, when there is no difference. Image-cleanup is done with onPageViewUpdates after a save delay. (In MediaWiki prior 1.18 i covered the Images onArticleSave and did cleanup onArticleSaveComplete. Trying to use PageContentSaveComplete leaded into removed covered images. Thats why i did that workarround using  onPageViewUpdates).

The second thing i needed is the usage of "!include" inside <uml>. Do be able to do it, you have to enhance the java command (-Dplantuml.include.path=directory)

The last nice-to-have is some replacement inside <uml>. For example disable multiple images via @startuml and @enduml or shortcuts for specific usage. 

I tried to create a clean PlantUML.body.php without any individual customization. So far customization of includep path and shortcuts have to be done in extension.json.

ps: i had problems with the getPageTitle function. I found "As a rule, do not use $wgTitle if it's not absolutely needed/ In short: Do not use it. Ever." in mediawiki documentation, so i used ?->getTitle()->getFulltext();